### PR TITLE
修复php补全问题,输入美元符号时也触发自动提示

### DIFF
--- a/补全实现.js
+++ b/补全实现.js
@@ -52,6 +52,6 @@ module.exports = function (context) {
     context.subscriptions.push(vscode.languages.registerCompletionItemProvider({ scheme: 'file', language: '*' }, {
         provideCompletionItems,
         resolveCompletionItem
-    }, '.'));
+    }, '.', '$'));
 };
 


### PR DESCRIPTION
另外php补全需要安装插件

![QQ截图20200627120958](https://user-images.githubusercontent.com/7814085/85914435-19632f80-b870-11ea-89f8-dd1af606cd71.png)
![QQ截图20200627121125](https://user-images.githubusercontent.com/7814085/85914436-1a945c80-b870-11ea-8349-0f29870f3955.png)
